### PR TITLE
Revert "Bump pylint from 2.14.5 to 2.15.3"

### DIFF
--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -1,3 +1,3 @@
-pylint==2.15.3
+pylint==2.14.5
 pylint-django==2.5.3
 pylint-celery==0.3


### PR DESCRIPTION
Reverts berv-uni-project/audio-watermark-web-services#126